### PR TITLE
Handle missing parquet engine

### DIFF
--- a/merge_ieee_subjects.py
+++ b/merge_ieee_subjects.py
@@ -217,7 +217,15 @@ def load_usage_any(usage_path: Path) -> pd.DataFrame:
     if suffix == ".csv":
         return pd.read_csv(usage_path)
     if suffix == ".parquet":
-        return pd.read_parquet(usage_path)
+        try:
+            return pd.read_parquet(usage_path)
+        except ImportError:
+            msg = (
+                "Parquet support requires optional dependency 'pyarrow' or 'fastparquet'."
+                " Please install one of them to load parquet files."
+            )
+            log.error(msg)
+            fail("Parquet engine unavailable")
     # default to Excel attempt
     return load_usage_autodetect_excel(usage_path)
 


### PR DESCRIPTION
## Summary
- Wrap pd.read_parquet in ImportError handler
- Log clear guidance on installing parquet engines before exiting

## Testing
- `python -m py_compile merge_ieee_subjects.py`
- `python merge_ieee_subjects.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68b97db93b4c832e8a919c30e781d1bf