### PR TITLE
refactor: resolve base paths from app directory

### DIFF
--- a/App.py
+++ b/App.py
@@ -41,7 +41,7 @@ st.markdown(
 )
 
 # --- Paths & helpers ---
-BASE = Path.cwd()
+BASE = Path(__file__).resolve().parent
 SCRIPT = BASE / "merge_ieee_subjects.py"
 DEFAULT_USAGE = BASE / "usage.xlsx"
 DEFAULT_KBART = BASE / "IEEEXplore_Global_IEL.xlsx"


### PR DESCRIPTION
## Summary
- derive base directory from `App.py` instead of working directory
- ensure script and default file paths reference this base

## Testing
- `pytest`
- `python -m py_compile App.py`


------
https://chatgpt.com/codex/tasks/task_b_68b97dc55c64832e99fe6cd2e4a80642